### PR TITLE
add the slice namespace to the sharedserviceslice resource

### DIFF
--- a/deploy/SharedServiceSlice_crd.yaml
+++ b/deploy/SharedServiceSlice_crd.yaml
@@ -20,3 +20,5 @@ spec:
               type: object
             service_type:
               type: string
+            slice_namespace:
+              type: string


### PR DESCRIPTION
## Description
Add a `slice_namespace` property to the SharedServiceSlice resource to be used for defaulting the Keycloak realm name to the slice namespace.

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/AEROGEAR-7564