### PR TITLE
Aerogear 7552 service to keycloak

### DIFF
--- a/cmd/keycloak-operator/main.go
+++ b/cmd/keycloak-operator/main.go
@@ -28,15 +28,23 @@ func printVersion() {
 
 var (
 	resyncFlag *int = new(int)
+	logLevel *string = new(string)
 )
 
 func init() {
 	flagset := flag.CommandLine
 	flagset.IntVar(resyncFlag, "resync", 7, "change the resync period")
+	flagset.StringVar(logLevel, "log-level", logrus.Level.String(logrus.InfoLevel), "Log level to use. Possible values: panic, fatal, error, warn, info, debug")
 	flagset.Parse(os.Args[1:])
 }
 
 func main() {
+	logLevel, err := logrus.ParseLevel(*logLevel)
+	if err != nil {
+		logrus.Errorf("Failed to parse log level: %v", err)
+	} else {
+		logrus.SetLevel(logLevel)
+	}
 	printVersion()
 	resource := v1alpha1.Group + "/" + v1alpha1.Version
 	namespace, err := k8sutil.GetWatchNamespace()

--- a/cmd/keycloak-operator/main.go
+++ b/cmd/keycloak-operator/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/k8sclient"
 	"github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	"github.com/sirupsen/logrus"
+	"os"
 )
 
 func printVersion() {
@@ -29,13 +30,14 @@ var (
 	resyncFlag *int = new(int)
 )
 
-func setFlags() {
-	flag.IntVar(resyncFlag, "resync", 7, "change the resync period")
+func init() {
+	flagset := flag.CommandLine
+	flagset.IntVar(resyncFlag, "resync", 7, "change the resync period")
+	flagset.Parse(os.Args[1:])
 }
 
 func main() {
 	printVersion()
-	setFlags()
 	resource := v1alpha1.Group + "/" + v1alpha1.Version
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {

--- a/deploy/examples/sharedservice.json
+++ b/deploy/examples/sharedservice.json
@@ -5,10 +5,10 @@
     "name": "example"
   },
   "spec": {
-    "service_type":"keycloak",
-    "slices_per_instance":3,
-    "maximum_instances":3,
-    "minimum_instances":1,
-    "required_instances": 1
+    "serviceType":"keycloak",
+    "maxSlices":3,
+    "maxInstances":3,
+    "minInstances":1,
+    "requiredInstances": 0
   }
 }

--- a/pkg/apis/aerogear/v1alpha1/shared.go
+++ b/pkg/apis/aerogear/v1alpha1/shared.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
@@ -10,15 +10,16 @@ const (
 	SharedServiceSliceKind  = "SharedServiceSlice"
 	SharedServicePlanKind   = "SharedServicePlan"
 	SharedServiceActionKind = "SharedServiceAction"
+	SharedServiceFinalizer  = "finalizer.org.aerogear.sharedService"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type SharedService struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata"`
-	Spec              SharedServiceSpec   `json:"spec"`
-	Status            SharedServiceStatus `json:"status"`
+	metav1.TypeMeta            `json:",inline"`
+	metav1.ObjectMeta          `json:"metadata"`
+	Spec   SharedServiceSpec   `json:"spec"`
+	Status SharedServiceStatus `json:"status"`
 }
 
 type SharedServiceStatus struct {
@@ -26,30 +27,33 @@ type SharedServiceStatus struct {
 }
 
 type CommonStatus struct {
-	Ready bool `json:"ready"`
+	Phase SharedServiceStatusPhase `json:"phase,omitempty"`
+	Ready bool                     `json:"ready"`
 }
 
 type SharedServiceSpec struct {
-	MaxInstances int `json:"maxInstances"`
-	MinInstances int `json:"minInstances"`
-	MaxSlices    int `json:"maxSlices"`
+	MaxInstances      int    `json:"maxInstances"`
+	MinInstances      int    `json:"minInstances"`
+	MaxSlices         int    `json:"maxSlices"`
+	RequiredInstances int    `json:"requiredInstances"`
+	ServiceType       string `json:"serviceType"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type SharedServiceList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
-	Items           []SharedService `json:"items"`
+	metav1.TypeMeta       `json:",inline"`
+	metav1.ListMeta       `json:"metadata"`
+	Items []SharedService `json:"items"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type SharedServiceSlice struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata"`
-	Spec              SharedServiceSliceSpec   `json:"spec"`
-	Status            SharedServiceSliceStatus `json:"status"`
+	metav1.TypeMeta                 `json:",inline"`
+	metav1.ObjectMeta               `json:"metadata"`
+	Spec   SharedServiceSliceSpec   `json:"spec"`
+	Status SharedServiceSliceStatus `json:"status"`
 }
 
 type SharedServiceSliceSpec struct {
@@ -66,18 +70,18 @@ type SharedServiceSliceStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type SharedServiceSliceList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
-	Items           []SharedServiceSlice `json:"items"`
+	metav1.TypeMeta            `json:",inline"`
+	metav1.ListMeta            `json:"metadata"`
+	Items []SharedServiceSlice `json:"items"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type SharedServicePlan struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata"`
-	Spec              SharedServicePlanSpec   `json:"spec"`
-	Status            SharedServicePlanStatus `json:"status"`
+	metav1.TypeMeta                `json:",inline"`
+	metav1.ObjectMeta              `json:"metadata"`
+	Spec   SharedServicePlanSpec   `json:"spec"`
+	Status SharedServicePlanStatus `json:"status"`
 }
 
 type SharedServicePlanSpec struct {
@@ -92,18 +96,18 @@ type SharedServicePlanStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type SharedServicePlanList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
-	Items           []SharedServicePlan `json:"items"`
+	metav1.TypeMeta           `json:",inline"`
+	metav1.ListMeta           `json:"metadata"`
+	Items []SharedServicePlan `json:"items"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type SharedServiceAction struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata"`
-	Spec              SharedServiceActionSpec   `json:"spec"`
-	Status            SharedServiceActionStatus `json:"status"`
+	metav1.TypeMeta                  `json:",inline"`
+	metav1.ObjectMeta                `json:"metadata"`
+	Spec   SharedServiceActionSpec   `json:"spec"`
+	Status SharedServiceActionStatus `json:"status"`
 }
 
 type SharedServiceActionSpec struct {
@@ -118,9 +122,9 @@ type SharedServiceActionStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type SharedServiceActionList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
-	Items           []SharedServiceAction `json:"items"`
+	metav1.TypeMeta             `json:",inline"`
+	metav1.ListMeta             `json:"metadata"`
+	Items []SharedServiceAction `json:"items"`
 }
 
 // StatusSharedConfig manages the capacity of a shared service
@@ -128,3 +132,11 @@ type StatusSharedConfig struct {
 	MaxSlices     int `json:"maxSlices"`
 	CurrentSlices int `json:"currentSlices"`
 }
+
+type SharedServiceStatusPhase string
+
+const (
+	SSPhaseNone                              = ""
+	SSPhaseAccepted SharedServiceStatusPhase = "accepted"
+	SSPhaseComplete SharedServiceStatusPhase = "complete"
+)

--- a/pkg/apis/aerogear/v1alpha1/types.go
+++ b/pkg/apis/aerogear/v1alpha1/types.go
@@ -8,6 +8,8 @@ const (
 	Group        = "aerogear.org"
 	Version      = "v1alpha1"
 	KeycloakKind = "Keycloak"
+	KeycloakVersion = "4.1.0"
+	KeycloakFinalizer = "finalizer.org.aerogrear.keycloak"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -24,7 +26,7 @@ type Keycloak struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 	Spec              KeycloakSpec  `json:"spec"`
-	Status            GenericStatus `json:"status,omitempty"`
+	Status            KeycloakStatus `json:"status,omitempty"`
 }
 
 func (k *Keycloak) Defaults() {

--- a/pkg/shared/service.go
+++ b/pkg/shared/service.go
@@ -2,11 +2,13 @@ package shared
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/aerogear/keycloak-operator/pkg/apis/aerogear/v1alpha1"
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+	"github.com/sirupsen/logrus"
+	sc "github.com/kubernetes-incubator/service-catalog/pkg/api/meta"
 )
 
 type ServiceHandler struct {
@@ -17,7 +19,139 @@ func NewServiceHandler() *ServiceHandler {
 }
 
 func (sh *ServiceHandler) Handle(ctx context.Context, event sdk.Event) error {
-	fmt.Println("handling object ", event.Object.GetObjectKind().GroupVersionKind().String())
+	logrus.Debug("handling object ", event.Object.GetObjectKind().GroupVersionKind().String())
+
+	sharedService := event.Object.(*v1alpha1.SharedService)
+	sharedServiceCopy := sharedService.DeepCopy()
+
+	if sharedService.Spec.ServiceType != strings.ToLower(v1alpha1.KeycloakKind) {
+		return nil
+	}
+
+	if event.Deleted {
+		return nil
+	}
+
+	if sharedService.GetDeletionTimestamp() != nil {
+		return sh.finalizeSharedService(sharedServiceCopy)
+	}
+
+	logrus.Debugf("SharedServicePhase: %v", sharedService.Status.Phase)
+	switch sharedService.Status.Phase {
+	case v1alpha1.SSPhaseNone:
+		sh.initSharedService(sharedServiceCopy)
+	case v1alpha1.SSPhaseAccepted:
+		sh.createKeycloaks(sharedServiceCopy)
+	}
+
+	return nil
+}
+
+func (sh *ServiceHandler) createKeycloaks(sharedService *v1alpha1.SharedService) error {
+	keycloakList := v1alpha1.KeycloakList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Keycloak",
+			APIVersion: "aerogear.org/v1alpha1",
+		},
+	}
+	listOptions := sdk.WithListOptions(&metav1.ListOptions{
+		LabelSelector:        "aerogear.org/sharedServiceName=" + sharedService.ObjectMeta.Name,
+		IncludeUninitialized: false,
+	})
+
+	err := sdk.List(sharedService.Namespace, &keycloakList, listOptions)
+	if err != nil {
+		logrus.Errorf("Failed to query keycloaks : %v", err)
+		return err
+	}
+
+	numCurrentInstances := len(keycloakList.Items)
+	numRequiredInstances := minRequiredInstances(sharedService.Spec.MinInstances, sharedService.Spec.RequiredInstances)
+	numMaxInstances := sharedService.Spec.MaxInstances
+	logrus.Debugf("number of service instances(%v), current: %v, required: %v, max: %v", sharedService.Spec.ServiceType, numCurrentInstances, numRequiredInstances, numMaxInstances)
+
+	if numCurrentInstances < numRequiredInstances && numCurrentInstances < numMaxInstances {
+		err := sdk.Create(newKeycloak(sharedService))
+		if err != nil {
+			logrus.Errorf("Failed to create keycloak : %v", err)
+			return err
+		}
+	} else {
+		sharedService.Status.Ready = true
+		sharedService.Status.Phase = v1alpha1.SSPhaseComplete
+		err := sdk.Update(sharedService)
+		if err != nil {
+			logrus.Errorf("error updating resource status: %v", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func minRequiredInstances(minInstances, requiredInstances int) int {
+	if minInstances > requiredInstances {
+		return minInstances
+	}
+	return requiredInstances
+}
+
+func newKeycloak(sharedService *v1alpha1.SharedService) *v1alpha1.Keycloak {
+	labels := map[string]string{
+		"aerogear.org/sharedServiceName": sharedService.ObjectMeta.Name,
+	}
+	return &v1alpha1.Keycloak{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Keycloak",
+			APIVersion: "aerogear.org/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: sharedService.Name + "-keycloak-",
+			Namespace:    sharedService.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(sharedService, schema.GroupVersionKind{
+					Group:   v1alpha1.SchemeGroupVersion.Group,
+					Version: v1alpha1.SchemeGroupVersion.Version,
+					Kind:    "SharedService",
+				}),
+			},
+			Finalizers: []string{v1alpha1.KeycloakFinalizer},
+			Labels: labels,
+		},
+		Spec: v1alpha1.KeycloakSpec{
+			Version:          v1alpha1.KeycloakVersion,
+			AdminCredentials: "",
+			Realms:           []v1alpha1.KeycloakRealm{},
+		},
+		Status: v1alpha1.KeycloakStatus{
+			SharedConfig: v1alpha1.StatusSharedConfig{
+				MaxSlices:     sharedService.Spec.MaxSlices,
+				CurrentSlices: 0,
+			},
+		},
+	}
+}
+
+func (sh *ServiceHandler) initSharedService(sharedService *v1alpha1.SharedService) error {
+	logrus.Infof("initialise shared service: %v", sharedService)
+	sc.AddFinalizer(sharedService, v1alpha1.SharedServiceFinalizer)
+	sharedService.Status.Phase = v1alpha1.SSPhaseAccepted
+	err := sdk.Update(sharedService)
+	if err != nil {
+		logrus.Errorf("error updating resource finalizer: %v", err)
+		return err
+	}
+	return nil
+}
+
+func (sh *ServiceHandler) finalizeSharedService(sharedService *v1alpha1.SharedService) error {
+	logrus.Infof("finalise shared service: %v", sharedService)
+	sc.RemoveFinalizer(sharedService, v1alpha1.SharedServiceFinalizer)
+	err := sdk.Update(sharedService)
+	if err != nil {
+		logrus.Errorf("error updating resource finalizer: %v", err)
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
* Fix an issue with parsing the operator flags.
* Add log level option:
```
operator-sdk up local --operator-flags="--resync=10 --log-level=debug" --namespace shared
```
* Updates the operator to handle SharedService resources being transformed into Keycloak resources.

JIra:

https://issues.jboss.org/browse/AEROGEAR-7552