### PR TITLE
Cleanup keycloak provision and deprovision

### DIFF
--- a/pkg/apis/aerogear/v1alpha1/types.go
+++ b/pkg/apis/aerogear/v1alpha1/types.go
@@ -5,11 +5,11 @@ import (
 )
 
 const (
-	Group        = "aerogear.org"
-	Version      = "v1alpha1"
-	KeycloakKind = "Keycloak"
-	KeycloakVersion = "4.1.0"
-	KeycloakFinalizer = "finalizer.org.aerogrear.keycloak"
+	Group             = "aerogear.org"
+	Version           = "v1alpha1"
+	KeycloakKind      = "Keycloak"
+	KeycloakVersion   = "4.1.0"
+	KeycloakFinalizer = "finalizer.org.aerogear.keycloak"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -25,7 +25,7 @@ type KeycloakList struct {
 type Keycloak struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
-	Spec              KeycloakSpec  `json:"spec"`
+	Spec              KeycloakSpec   `json:"spec"`
 	Status            KeycloakStatus `json:"status,omitempty"`
 }
 


### PR DESCRIPTION
## Description 
Fix typo on keycloak finalizer. Remove the duplicate removal of the finalizer in the keycloak custom resource and duplicate sdk update.